### PR TITLE
Keep UTM params when redirecting from index page

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -22,20 +22,27 @@ use App\Http\Middleware\LoginAutomatically;
 // Manually switch authenticated user
 Route::post('/login', [LoginController::class, 'login']);
 
-// Defaults to deals page
-Route::redirect('/', '/deals');
+// Defaults to deals page, but maintains the UTM parameters
+Route::get('/', function () {
+    $queryParams = [];
+    $queryParams['utm_source'] = request()->query('utm_source');
+    $queryParams['utm_medium'] = request()->query('utm_medium');
+    $queryParams['utm_campaign'] =request()->query('utm_campaign');
+
+    return redirect()->route('deals.index', $queryParams);
+});
 
 // Login the user with ID 1 if no user is logged in
 Route::middleware([LoginAutomatically::class])->group(function () {
-    
+
     Route::resource('companies', CompanyController::class)->only([
         'index', 'show'
-    ]);   
+    ]);
 
     Route::resource('contacts', ContactController::class)->only([
         'index', 'show'
     ]);
-    
+
     Route::resource('deals', DealController::class)->only([
         'index', 'show'
     ]);


### PR DESCRIPTION
## Issue

UTMs parameters are [missing from analytics](https://app.usefathom.com/?comparison=none&filters%5B0%5D%5Boperator%5D=is&filters%5B0%5D%5Bproperty%5D=Campaign&filters%5B0%5D%5Bvalue%5D=oss&filters%5B1%5D%5Boperator%5D=is&filters%5B1%5D%5Bproperty%5D=Source&filters%5B1%5D%5Bvalue%5D=docs&filters%5B2%5D%5Boperator%5D=is&filters%5B2%5D%5Bproperty%5D=Medium&filters%5B2%5D%5Bvalue%5D=home-page&range=this_year&site=QNBPJXIV) are missing for `saas.meilisearch.com` because `/` redirects to `/deals` and URL parameters are lost in the process.

## Solution

Maintain `utm_campaign`, `utm_source`, and `utm_content` URL parameters when redirecting from `/`