### PR TITLE
Fix healthcheck by doing GET instead of HEAD and verify content

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,7 +80,7 @@ services:
         networks:
             - sail
         healthcheck:
-            test: curl -fsS http://localhost:7700/health | grep -q '{"status":"available"}'
+            test: set -o pipefail;curl -fsS http://localhost:7700/health | grep -q '{"status":"available"}'
             retries: 3
             timeout: 5s
     mailpit:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,12 +80,7 @@ services:
         networks:
             - sail
         healthcheck:
-            test:
-                - CMD
-                - wget
-                - '--no-verbose'
-                - '--spider'
-                - 'http://localhost:7700/health'
+            test: curl -fsS http://localhost:7700/health | grep -q '{"status":"available"}'
             retries: 3
             timeout: 5s
     mailpit:


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Changes Docker Compose health check of the meilisearch service to make a GET request instead of HEAD because the health endpoint responds to with 405 Method not allowed to HEAD.

In addition, it also ensures the content is right.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
